### PR TITLE
Added option for randomized grids for stress divergence test cases

### DIFF
--- a/testcases/spherical_operators/spherical_operators_hist.py
+++ b/testcases/spherical_operators/spherical_operators_hist.py
@@ -186,7 +186,7 @@ def strain_hist(axis):
 def stress_divergence_hist(axis):
 
     # grid
-    fileGrid = Dataset("./stress_divergence/grid.40962.nc","r")
+    fileGrid = Dataset("./stress_divergence/grid.regular.40962.nc","r")
 
     nVertices = len(fileGrid.dimensions["nVertices"])
 
@@ -196,7 +196,7 @@ def stress_divergence_hist(axis):
 
 
     # ic
-    fileIC = Dataset("./stress_divergence/ic_40962.nc","r")
+    fileIC = Dataset("./stress_divergence/ic_regular.40962.nc","r")
 
     uVelocity = fileIC.variables["uVelocity"][:]
     vVelocity = fileIC.variables["vVelocity"][:]
@@ -211,7 +211,7 @@ def stress_divergence_hist(axis):
     fileIC.close()
 
     # Wachspress
-    fileWach = Dataset("./stress_divergence/output_wachspress_40962/output.2000.nc","r")
+    fileWach = Dataset("./stress_divergence/output_regular_wachspress_40962/output.2000.nc","r")
 
     stressDivergenceUWach = fileWach.variables["stressDivergenceU"][0,:]
     stressDivergenceVWach = fileWach.variables["stressDivergenceV"][0,:]
@@ -226,7 +226,7 @@ def stress_divergence_hist(axis):
     fileWach.close()
 
     # PWL
-    filePWL = Dataset("./stress_divergence/output_pwl_40962/output.2000.nc","r")
+    filePWL = Dataset("./stress_divergence/output_regular_pwl_40962/output.2000.nc","r")
 
     stressDivergenceUPWL = filePWL.variables["stressDivergenceU"][0,:]
     stressDivergenceVPWL = filePWL.variables["stressDivergenceV"][0,:]
@@ -241,7 +241,7 @@ def stress_divergence_hist(axis):
     filePWL.close()
 
     # Wachspress alt
-    fileWachAlt = Dataset("./stress_divergence/output_wachspress_alt_40962/output.2000.nc","r")
+    fileWachAlt = Dataset("./stress_divergence/output_regular_wachspress_alt_40962/output.2000.nc","r")
 
     stressDivergenceUWachAlt = fileWachAlt.variables["stressDivergenceU"][0,:]
     stressDivergenceVWachAlt = fileWachAlt.variables["stressDivergenceV"][0,:]
@@ -256,7 +256,7 @@ def stress_divergence_hist(axis):
     fileWachAlt.close()
 
     # PWL alt
-    filePWLAlt = Dataset("./stress_divergence/output_pwl_alt_40962/output.2000.nc","r")
+    filePWLAlt = Dataset("./stress_divergence/output_regular_pwl_alt_40962/output.2000.nc","r")
 
     stressDivergenceUPWLAlt = filePWLAlt.variables["stressDivergenceU"][0,:]
     stressDivergenceVPWLAlt = filePWLAlt.variables["stressDivergenceV"][0,:]
@@ -271,7 +271,7 @@ def stress_divergence_hist(axis):
     filePWLAlt.close()
 
     # Weak
-    fileWeak = Dataset("./stress_divergence/output_weak_40962/output.2000.nc","r")
+    fileWeak = Dataset("./stress_divergence/output_regular_weak_40962/output.2000.nc","r")
 
     stressDivergenceUWeak = fileWeak.variables["stressDivergenceU"][0,:]
     stressDivergenceVWeak = fileWeak.variables["stressDivergenceV"][0,:]

--- a/testcases/spherical_operators/spherical_operators_map.py
+++ b/testcases/spherical_operators/spherical_operators_map.py
@@ -329,7 +329,7 @@ def spherical_operators_map():
     print("Stress divergence")
 
     # ic
-    fileIC = Dataset("./stress_divergence/ic_40962.nc","r")
+    fileIC = Dataset("./stress_divergence/ic_regular.40962.nc","r")
 
     uVelocity = fileIC.variables["uVelocity"][:]
     vVelocity = fileIC.variables["vVelocity"][:]
@@ -344,7 +344,7 @@ def spherical_operators_map():
     fileIC.close()
 
     # Wachspress
-    fileWach = Dataset("./stress_divergence/output_wachspress_40962/output.2000.nc","r")
+    fileWach = Dataset("./stress_divergence/output_regular_wachspress_40962/output.2000.nc","r")
 
     stressDivergenceUWach = fileWach.variables["stressDivergenceU"][0,:]
     stressDivergenceVWach = fileWach.variables["stressDivergenceV"][0,:]
@@ -359,7 +359,7 @@ def spherical_operators_map():
     fileWach.close()
 
     # Wachspress alt
-    fileWach = Dataset("./stress_divergence/output_wachspress_alt_40962/output.2000.nc","r")
+    fileWach = Dataset("./stress_divergence/output_regular_wachspress_alt_40962/output.2000.nc","r")
 
     stressDivergenceUWachAlt = fileWach.variables["stressDivergenceU"][0,:]
     stressDivergenceVWachAlt = fileWach.variables["stressDivergenceV"][0,:]
@@ -374,7 +374,7 @@ def spherical_operators_map():
     fileWach.close()
 
     # PWL
-    filePWL = Dataset("./stress_divergence/output_pwl_40962/output.2000.nc","r")
+    filePWL = Dataset("./stress_divergence/output_regular_pwl_40962/output.2000.nc","r")
 
     stressDivergenceUPWL = filePWL.variables["stressDivergenceU"][0,:]
     stressDivergenceVPWL = filePWL.variables["stressDivergenceV"][0,:]
@@ -389,7 +389,7 @@ def spherical_operators_map():
     filePWL.close()
 
     # PWL Alt
-    filePWL = Dataset("./stress_divergence/output_pwl_alt_40962/output.2000.nc","r")
+    filePWL = Dataset("./stress_divergence/output_regular_pwl_alt_40962/output.2000.nc","r")
 
     stressDivergenceUPWLAlt = filePWL.variables["stressDivergenceU"][0,:]
     stressDivergenceVPWLAlt = filePWL.variables["stressDivergenceV"][0,:]
@@ -404,7 +404,7 @@ def spherical_operators_map():
     filePWL.close()
 
     # Weak
-    fileWeak = Dataset("./stress_divergence/output_weak_40962/output.2000.nc","r")
+    fileWeak = Dataset("./stress_divergence/output_regular_weak_40962/output.2000.nc","r")
 
     stressDivergenceUWeak = fileWeak.variables["stressDivergenceU"][0,:]
     stressDivergenceVWeak = fileWeak.variables["stressDivergenceV"][0,:]
@@ -525,7 +525,7 @@ def spherical_operators_map():
                         wspace=0.43,
                         hspace=0.2)
 
-    positionTypeWrite = "read"
+    positionTypeWrite = "write"
 
     if (positionTypeWrite == "read"):
 

--- a/testcases/spherical_operators/spherical_operators_scaling.py
+++ b/testcases/spherical_operators/spherical_operators_scaling.py
@@ -1947,8 +1947,8 @@ def stress_divergence_scaling(axes, normType, label, xlabel, xMin, xMax, yMin):
 
         for resolution in resolutions:
 
-            filename = "./stress_divergence/output_%s_%i/output.2000.nc" %(method,resolution)
-            filenameIC = "./stress_divergence/ic_%i.nc" %(resolution)
+            filename = "./stress_divergence/output_regular_%s_%i/output.2000.nc" %(method,resolution)
+            filenameIC = "./stress_divergence/ic_regular.%i.nc" %(resolution)
 
             print(filename, filenameIC)
 

--- a/testcases/spherical_operators/strain/get_testcase_data.py
+++ b/testcases/spherical_operators/strain/get_testcase_data.py
@@ -1,4 +1,5 @@
 import subprocess
+from os.path import exists
 
 #-------------------------------------------------------------------------------
 
@@ -13,12 +14,16 @@ def get_testcase_data():
 
     for filename in filenames:
 
-        args = ["wget", dirName+filename]
+        totalFilename = dirName+filename
 
-        process = subprocess.Popen(args, stdout=subprocess.PIPE)
+        if (not exists(filename)):
 
-        while process.poll() is None:
-            line = process.stdout.readline()
+            args = ["wget", totalFilename]
+
+            process = subprocess.Popen(args, stdout=subprocess.PIPE)
+
+            while process.poll() is None:
+                line = process.stdout.readline()
 
 #-------------------------------------------------------------------------------
 

--- a/testcases/spherical_operators/stress_divergence/create_ic.py
+++ b/testcases/spherical_operators/stress_divergence/create_ic.py
@@ -635,7 +635,7 @@ def latlon_from_xyz(x, y, z, r):
 
 #-------------------------------------------------------------------------------
 
-def create_ic():
+def create_ic(testName):
 
     mu = 3
     lu = 5
@@ -653,7 +653,7 @@ def create_ic():
         print("  Gridsize: ", gridSize)
 
         # input
-        filenameIn = "grid.%i.nc" %(gridSize)
+        filenameIn = "grid.%s.%i.nc" %(testName,gridSize)
 
         fileIn = Dataset(filenameIn,"r")
 
@@ -742,7 +742,7 @@ def create_ic():
                 strain12CellVarAnalytical[iCell,iVertexOnCell] = strain12VertexAnalytical[iVertex]
 
         # output
-        filenameOut = "ic_%i.nc" %(gridSize)
+        filenameOut = "ic_%s.%i.nc" %(testName,gridSize)
 
         fileOut = Dataset(filenameOut, "w", format="NETCDF3_CLASSIC")
 
@@ -789,4 +789,10 @@ def create_ic():
 
 if __name__ == "__main__":
 
-    create_ic()
+    parser = argparse.ArgumentParser(description='')
+
+    parser.add_argument('-t', dest='testName', help='')
+
+    args = parser.parse_args()
+
+    create_ic(args.testName)

--- a/testcases/spherical_operators/stress_divergence/get_testcase_data.py
+++ b/testcases/spherical_operators/stress_divergence/get_testcase_data.py
@@ -1,4 +1,5 @@
 import subprocess
+from os.path import exists
 
 #-------------------------------------------------------------------------------
 
@@ -13,12 +14,16 @@ def get_testcase_data():
 
     for filename in filenames:
 
-        args = ["wget", dirName+filename]
+        totalFilename = dirName+filename
 
-        process = subprocess.Popen(args, stdout=subprocess.PIPE)
+        if (not exists(filename)):
 
-        while process.poll() is None:
-            line = process.stdout.readline()
+            args = ["wget", totalFilename]
+
+            process = subprocess.Popen(args, stdout=subprocess.PIPE)
+
+            while process.poll() is None:
+                line = process.stdout.readline()
 
 #-------------------------------------------------------------------------------
 

--- a/testcases/spherical_operators/stress_divergence/randomize_mesh.py
+++ b/testcases/spherical_operators/stress_divergence/randomize_mesh.py
@@ -1,0 +1,125 @@
+import argparse
+import numpy as np
+import os
+from netCDF4 import Dataset
+
+#-------------------------------------------------------------------------------
+
+def randomize_delta_on_sphere(x, y, z, ds):
+
+    r = np.array([x,y,z])
+    rmag = np.linalg.norm(r)
+    a = np.array([np.random.uniform(-1.0,1.0),
+                  np.random.uniform(-1.0,1.0),
+                  np.random.uniform(-1.0,1.0)])
+    e1 = np.cross(r,a)
+    e2 = np.cross(e1,r)
+    norm1 = np.linalg.norm(e1)
+    norm2 = np.linalg.norm(e2)
+    e1[:] /= norm1
+    e2[:] /= norm2
+
+    ds1 = ds * np.random.uniform(-1.0,1.0)
+    ds2 = ds * np.random.uniform(-1.0,1.0)
+
+    dx = ds1 * e1[0] + ds2 * e2[0]
+    dy = ds1 * e1[1] + ds2 * e2[1]
+    dz = ds1 * e1[2] + ds2 * e2[2]
+
+    return dx, dy, dz
+
+#-------------------------------------------------------------------------------
+
+def randomize_mesh(meshType, meshScale):
+
+    if (meshType == "regular"):
+        testName = "regular"
+    elif (meshType == "random"):
+        testName = "random_%f" %(meshScale)
+
+    mpas_tools_dir = os.environ['MPAS_TOOLS_DIR']
+
+    meshes = [2562,10242,40962,163842]
+
+    for mesh in meshes:
+
+        gridnameIn = "grid.%i.nc" %(mesh)
+        gridnameIntermediate = "grid.inter.%i.nc" %(mesh)
+        os.system("cp %s %s" %(gridnameIn,gridnameIntermediate))
+
+        filein = Dataset(gridnameIntermediate,"a")
+
+        nCells = len(filein.dimensions["nCells"])
+        nVertices = len(filein.dimensions["nVertices"])
+
+        dcEdge = filein.variables["dcEdge"][:]
+        avgDcEdge = np.mean(dcEdge)
+
+        varxCell = filein.variables["xCell"]
+        varyCell = filein.variables["yCell"]
+        varzCell = filein.variables["zCell"]
+
+        xCell = varxCell[:]
+        yCell = varyCell[:]
+        zCell = varzCell[:]
+
+        varxVertex = filein.variables["xVertex"]
+        varyVertex = filein.variables["yVertex"]
+        varzVertex = filein.variables["zVertex"]
+
+        xVertex = varxVertex[:]
+        yVertex = varyVertex[:]
+        zVertex = varzVertex[:]
+
+        if (meshType == "random"):
+
+            for iCell in range(0,nCells):
+                normOld = np.linalg.norm([xCell[iCell], yCell[iCell], zCell[iCell]])
+                dx, dy, dz = randomize_delta_on_sphere(xCell[iCell], yCell[iCell], zCell[iCell], avgDcEdge*meshScale)
+                xCell[iCell] += dx
+                yCell[iCell] += dy
+                zCell[iCell] += dz
+                normNew = np.linalg.norm([xCell[iCell], yCell[iCell], zCell[iCell]])
+                xCell[iCell] *= (normOld/normNew)
+                yCell[iCell] *= (normOld/normNew)
+                zCell[iCell] *= (normOld/normNew)
+
+            for iVertex in range(0,nVertices):
+                normOld = np.linalg.norm([xVertex[iVertex], yVertex[iVertex], zVertex[iVertex]])
+                dx, dy, dz = randomize_delta_on_sphere(xVertex[iVertex], yVertex[iVertex], zVertex[iVertex], avgDcEdge*meshScale)
+                xVertex[iVertex] += dx
+                yVertex[iVertex] += dy
+                zVertex[iVertex] += dy
+                normNew = np.linalg.norm([xVertex[iVertex], yVertex[iVertex], zVertex[iVertex]])
+                xVertex[iVertex] *= (normOld/normNew)
+                yVertex[iVertex] *= (normOld/normNew)
+                zVertex[iVertex] *= (normOld/normNew)
+
+        varxCell[:] = xCell[:]
+        varyCell[:] = yCell[:]
+        varzCell[:] = zCell[:]
+
+        varxVertex[:] = xVertex[:]
+        varyVertex[:] = yVertex[:]
+        varzVertex[:] = zVertex[:]
+
+        filein.close()
+
+        gridnameOut = "grid.%s.%i.nc" %(testName,mesh)
+
+        os.system("%s/mesh_tools/mesh_conversion_tools/MpasMeshConverter.x %s %s" %(mpas_tools_dir,gridnameIntermediate,gridnameOut))
+
+    return testName
+
+#-------------------------------------------------------------------------------
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description='')
+
+    parser.add_argument('-t', dest='meshType', default="regular", choices=['regular','random'], help='')
+    parser.add_argument('-s', dest='meshScale', type=float, help='')
+
+    args = parser.parse_args()
+
+    randomize_mesh()

--- a/testcases/spherical_operators/stress_divergence/run_model.py
+++ b/testcases/spherical_operators/stress_divergence/run_model.py
@@ -1,4 +1,5 @@
 import os
+import argparse
 try:
     import f90nml
 except ImportError:
@@ -7,7 +8,7 @@ except ImportError:
 
 #-------------------------------------------------------------------------------
 
-def run_model():
+def run_model(testName):
 
     MPAS_SEAICE_EXECUTABLE = os.environ.get('MPAS_SEAICE_EXECUTABLE')
     MPAS_SEAICE_TESTCASES_RUN_COMMAND = os.environ.get('MPAS_SEAICE_TESTCASES_RUN_COMMAND')
@@ -27,8 +28,8 @@ def run_model():
             print("  Gridsize: ", gridSize)
 
             os.system("rm grid.nc ic.nc")
-            os.system("ln -s grid.%i.nc grid.nc" %(gridSize))
-            os.system("ln -s ic_%i.nc ic.nc" %(gridSize))
+            os.system("ln -s grid.%s.%i.nc grid.nc" %(testName,gridSize))
+            os.system("ln -s ic_%s.%i.nc ic.nc" %(testName,gridSize))
 
             if (operatorMethod == "wachspress"):
                 nmlPatch = {"velocity_solver": {"config_strain_scheme":"variational",
@@ -63,10 +64,16 @@ def run_model():
 
             os.system("%s %s" %(MPAS_SEAICE_TESTCASES_RUN_COMMAND, MPAS_SEAICE_EXECUTABLE))
 
-            os.system("mv output output_%s_%i" %(operatorMethod, gridSize))
+            os.system("mv output output_%s_%s_%i" %(testName, operatorMethod, gridSize))
 
 #-------------------------------------------------------------------------------
 
 if __name__ == "__main__":
 
-    run_model()
+    parser = argparse.ArgumentParser(description='')
+
+    parser.add_argument('-t', dest='testName', help='')
+
+    args = parser.parse_args()
+
+    run_model(args.testName)

--- a/testcases/spherical_operators/stress_divergence/run_testcase.py
+++ b/testcases/spherical_operators/stress_divergence/run_testcase.py
@@ -1,25 +1,36 @@
 from get_testcase_data import get_testcase_data
+from randomize_mesh import randomize_mesh
 from create_ic import create_ic
 from run_model import run_model
 from stress_divergence_map import stress_divergence_map
 from stress_divergence_scaling import stress_divergence_scaling
+import argparse
 
 #-------------------------------------------------------------------------------
 
-def run_stress_divergence_testcase():
+def run_stress_divergence_testcase(meshType, meshScale):
 
     get_testcase_data()
 
-    create_ic()
+    testName = randomize_mesh(meshType, meshScale)
 
-    run_model()
+    create_ic(testName)
 
-    stress_divergence_map()
+    run_model(testName)
 
-    stress_divergence_scaling()
+    stress_divergence_map(testName)
+
+    stress_divergence_scaling(testName)
 
 #-------------------------------------------------------------------------------
 
 if __name__ == "__main__":
 
-    run_stress_divergence_testcase()
+    parser = argparse.ArgumentParser(description='')
+
+    parser.add_argument('-t', dest='meshType', default="regular", choices=['regular','random'], help='')
+    parser.add_argument('-s', dest='meshScale', type=float, help='')
+
+    args = parser.parse_args()
+
+    run_stress_divergence_testcase(args.meshType, args.meshScale)

--- a/testcases/spherical_operators/stress_divergence/stress_divergence_map.py
+++ b/testcases/spherical_operators/stress_divergence/stress_divergence_map.py
@@ -95,10 +95,10 @@ def plot_subfigure(axes, fig, nVertices, vertexDegree, cellsOnVertex, xCell, yCe
 
 #---------------------------------------------------------------
 
-def stress_divergence_map():
+def stress_divergence_map(testName):
 
     # grid
-    fileGrid = Dataset("grid.40962.nc","r")
+    fileGrid = Dataset("grid.%s.40962.nc" %(testName),"r")
 
     nCells = len(fileGrid.dimensions["nCells"])
     nVertices = len(fileGrid.dimensions["nVertices"])
@@ -127,7 +127,7 @@ def stress_divergence_map():
     fileGrid.close()
 
     # ic
-    fileIC = Dataset("ic_40962.nc","r")
+    fileIC = Dataset("ic_%s.40962.nc" %(testName),"r")
 
     uVelocity = fileIC.variables["uVelocity"][:]
     vVelocity = fileIC.variables["vVelocity"][:]
@@ -142,7 +142,7 @@ def stress_divergence_map():
     fileIC.close()
 
     # Wachspress
-    fileWach = Dataset("./output_wachspress_40962/output.2000.nc","r")
+    fileWach = Dataset("./output_%s_wachspress_40962/output.2000.nc" %(testName),"r")
 
     stressDivergenceUWach = fileWach.variables["stressDivergenceU"][0,:]
     stressDivergenceVWach = fileWach.variables["stressDivergenceV"][0,:]
@@ -157,7 +157,7 @@ def stress_divergence_map():
     fileWach.close()
 
     # PWL
-    filePWL = Dataset("./output_pwl_40962/output.2000.nc","r")
+    filePWL = Dataset("./output_%s_pwl_40962/output.2000.nc" %(testName),"r")
 
     stressDivergenceUPWL = filePWL.variables["stressDivergenceU"][0,:]
     stressDivergenceVPWL = filePWL.variables["stressDivergenceV"][0,:]
@@ -172,7 +172,7 @@ def stress_divergence_map():
     filePWL.close()
 
     # Weak
-    fileWeak = Dataset("./output_weak_40962/output.2000.nc","r")
+    fileWeak = Dataset("./output_%s_weak_40962/output.2000.nc" %(testName),"r")
 
     stressDivergenceUWeak = fileWeak.variables["stressDivergenceU"][0,:]
     stressDivergenceVWeak = fileWeak.variables["stressDivergenceV"][0,:]
@@ -243,8 +243,7 @@ def stress_divergence_map():
                    False, False, r'Weak ($v^\prime$ direction)', '(p)', True)
 
     #plt.tight_layout(pad=0.5, w_pad=0.5, h_pad=0.5)
-    plt.savefig("stress_divergence_map.png",dpi=400)
-    #plt.savefig("stress_divergence_map_3.png", bbox_inches="tight",dpi=2000)
+    plt.savefig("stress_divergence_map_%s.png" %(testName),dpi=400)
 
     plt.clf()
     plt.cla()
@@ -294,10 +293,16 @@ def stress_divergence_map():
 
     plt.tight_layout(pad=0.5, w_pad=0.5, h_pad=0.5)
 
-    plt.savefig("stress_divergence_hist.png",dpi=400)
+    plt.savefig("stress_divergence_hist_%s.png" %(testName),dpi=400)
 
 #-------------------------------------------------------------------------------
 
 if __name__ == "__main__":
 
-    stress_divergence_map()
+    parser = argparse.ArgumentParser(description='')
+
+    parser.add_argument('-t', dest='testName', help='')
+
+    args = parser.parse_args()
+
+    stress_divergence_map(args.testName)

--- a/testcases/spherical_operators/stress_divergence/stress_divergence_scaling_per_random.py
+++ b/testcases/spherical_operators/stress_divergence/stress_divergence_scaling_per_random.py
@@ -1,115 +1,13 @@
-from netCDF4 import Dataset
-import math
+from stress_divergence_scaling import scaling_lines, get_norm, get_resolution
 import matplotlib.pyplot as plt
-import matplotlib as mpl
-import argparse
 
-#--------------------------------------------------------
+#-------------------------------------------------------------------------------
 
-def L2_norm(numerical, analytical, nVertices, latVertex, areaTriangle, latitudeLimit):
+def stress_divergence_scaling_per_random():
 
-    degreesToRadians = math.pi / 180.0
-
-    L2_norm  = 0.0
-    Linf_norm = 0.0
-    denom = 0.0
-
-    for iVertex in range(0,nVertices):
-
-        if (math.fabs(latVertex[iVertex]) > latitudeLimit * degreesToRadians):
-
-            L2_norm  = L2_norm  + areaTriangle[iVertex] * math.pow(numerical[iVertex] - analytical[iVertex],2)
-            denom    = denom    + areaTriangle[iVertex] * math.pow(analytical[iVertex],2)
-
-            Linf_norm = max(Linf_norm,math.fabs(numerical[iVertex] - analytical[iVertex]))
-
-    L2_norm = math.sqrt(L2_norm / denom)
-
-    return L2_norm, Linf_norm
-
-#--------------------------------------------------------
-
-def get_norm(filenameIC, filename, latitudeLimit):
-
-    fileIC = Dataset(filenameIC, "r")
-
-    stressDivergenceUAnalytical = fileIC.variables["stressDivergenceUAnalytical"][:]
-    stressDivergenceVAnalytical = fileIC.variables["stressDivergenceVAnalytical"][:]
-
-    fileIC.close()
-
-    fileMPAS = Dataset(filename, "r")
-
-    nVertices = len(fileMPAS.dimensions["nVertices"])
-
-    latVertex = fileMPAS.variables["latVertex"][:]
-
-    areaTriangle = fileMPAS.variables["areaTriangle"][:]
-
-    stressDivergenceU = fileMPAS.variables["stressDivergenceU"][0,:]
-    stressDivergenceV = fileMPAS.variables["stressDivergenceV"][0,:]
-
-    L2_normU, Linf_normU = L2_norm(stressDivergenceU, stressDivergenceUAnalytical, nVertices, latVertex, areaTriangle, latitudeLimit)
-    L2_normV, Linf_normV = L2_norm(stressDivergenceV, stressDivergenceVAnalytical, nVertices, latVertex, areaTriangle, latitudeLimit)
-
-    fileMPAS.close()
-
-    return L2_normU, L2_normV, Linf_normU, Linf_normV
-
-#--------------------------------------------------------
-
-def get_resolution(filename, latitudeLimit):
-
-    fileMPAS = Dataset(filename, "r")
-
-    nCells = len(fileMPAS.dimensions["nCells"])
-    nEdges = len(fileMPAS.dimensions["nEdges"])
-
-    degreesToRadians = math.pi / 180.0
-
-    dcEdge = fileMPAS.variables["dcEdge"][:]
-    latEdge = fileMPAS.variables["latEdge"][:]
-
-    resolution = 0.0
-    denom = 0.0
-    for iEdge in range(0,nEdges):
-        if (math.fabs(latEdge[iEdge]) > latitudeLimit * degreesToRadians):
-            resolution = resolution + dcEdge[iEdge]
-            denom = denom + 1.0
-
-    resolution = resolution / denom
-
-    fileMPAS.close()
-
-    return resolution
-
-#--------------------------------------------------------
-
-def scaling_lines(axis, xMin, xMax, yMin):
-
-    # linear scaling
-    scale = yMin / math.pow(xMin,1)
-    scaleMinLin = math.pow(xMin,1) * scale
-    scaleMaxLin = math.pow(xMax,1) * scale
-
-    # quadratic scaling
-    scale = yMin / math.pow(xMin,2)
-    scaleMinQuad = math.pow(xMin,2) * scale
-    scaleMaxQuad = math.pow(xMax,2) * scale
-
-    axis.loglog([xMin, xMax], [scaleMinLin,  scaleMaxLin],  linestyle=':', color='k')
-    axis.loglog([xMin, xMax], [scaleMinQuad, scaleMaxQuad], linestyle=':', color='k')
-
-#--------------------------------------------------------
-
-def stress_divergence_scaling(testName):
-
+    meshScales = [0.0,0.01,0.02,0.04]
+    method = "pwl_alt"
     resolutions = [2562,10242,40962,163842]
-
-    #methods = ["wachspress", "pwl", "weak", "wachspress_alt", "pwl_alt"]
-    methods = ["wachspress", "pwl", "wachspress_alt", "pwl_alt"]
-
-
     latitudeLimit = 20.0
 
     # plot options
@@ -166,9 +64,12 @@ def stress_divergence_scaling(testName):
     scaling_lines(axes[1,0], xMin, xMax, yMin_Linf)
     scaling_lines(axes[1,1], xMin, xMax, yMin_Linf)
 
-    for method in methods:
 
-        print("Operator method: ", method)
+    for meshScale in meshScales:
+
+        print("Mesh scale: ", meshScale)
+
+        testName = "random_%f" %(meshScale)
 
         x = []
         y_L2U = []
@@ -181,7 +82,7 @@ def stress_divergence_scaling(testName):
             filename = "./output_%s_%s_%i/output.2000.nc" %(testName,method,resolution)
             filenameIC = "./ic_%s.%i.nc" %(testName,resolution)
 
-            print("  ", filename, filenameIC)
+            print(filename, filenameIC)
 
             L2_normU, L2_normV, Linf_normU, Linf_normV = get_norm(filenameIC, filename, latitudeLimit)
 
@@ -196,20 +97,19 @@ def stress_divergence_scaling(testName):
         axes[1,0].loglog(x,y_LinfU, marker=markers[method], color=lineColors[method], ls=lineStyles[method], markersize=5.0, label=legendLabels[method])
         axes[1,1].loglog(x,y_LinfV, marker=markers[method], color=lineColors[method], ls=lineStyles[method], markersize=5.0, label=legendLabels[method])
 
-
     axes[0,0].legend(frameon=False, loc=2, fontsize=8, handlelength=4)
-    axes[0,0].set_xlabel(None)
+    axes[0,0].set_xlabel("Grid resolution")
     axes[0,0].set_ylabel(r"$L_2$ error norm")
-    axes[0,0].set_title(r'(a) $(\nabla \cdot \sigma)_u$', loc="left")
+    axes[0,0].set_title(r'$(\nabla \cdot \sigma)_u$')
     axes[0,0].set_xticks(ticks=[9e-3,2e-2,3e-2,4e-2,6e-2,7e-2,8e-2],minor=True)
     axes[0,0].set_xticklabels(labels=[None,None,None,None,None,None,None],minor=True)
     axes[0,0].set_xticks(ticks=[1e-2,5e-2],minor=False)
     axes[0,0].set_xticklabels(labels=[r'$10^{-2}$',r'$5\times10^{-2}$'],minor=False)
 
     axes[0,1].legend(frameon=False, loc=2, fontsize=8, handlelength=4)
-    axes[0,1].set_xlabel(None)
-    axes[0,1].set_ylabel(None)
-    axes[0,1].set_title(r'(b) $(\nabla \cdot \sigma)_v$', loc="left")
+    axes[0,1].set_xlabel("Grid resolution")
+    axes[0,1].set_ylabel(r"$L_2$ error norm")
+    axes[0,1].set_title(r'$(\nabla \cdot \sigma)_v$')
     axes[0,1].set_xticks(ticks=[9e-3,2e-2,3e-2,4e-2,6e-2,7e-2,8e-2],minor=True)
     axes[0,1].set_xticklabels(labels=[None,None,None,None,None,None,None],minor=True)
     axes[0,1].set_xticks(ticks=[1e-2,5e-2],minor=False)
@@ -218,7 +118,7 @@ def stress_divergence_scaling(testName):
     axes[1,0].legend(frameon=False, loc=2, fontsize=8, handlelength=4)
     axes[1,0].set_xlabel("Grid resolution")
     axes[1,0].set_ylabel(r"$L_\infty$ error norm")
-    axes[1,0].set_title(r'(c) $(\nabla \cdot \sigma)_u$', loc="left")
+    axes[1,0].set_title(r'$(\nabla \cdot \sigma)_u$')
     axes[1,0].set_xticks(ticks=[9e-3,2e-2,3e-2,4e-2,6e-2,7e-2,8e-2],minor=True)
     axes[1,0].set_xticklabels(labels=[None,None,None,None,None,None,None],minor=True)
     axes[1,0].set_xticks(ticks=[1e-2,5e-2],minor=False)
@@ -226,24 +126,20 @@ def stress_divergence_scaling(testName):
 
     axes[1,1].legend(frameon=False, loc=2, fontsize=8, handlelength=4)
     axes[1,1].set_xlabel("Grid resolution")
-    axes[1,1].set_ylabel(None)
-    axes[1,1].set_title(r'(d) $(\nabla \cdot \sigma)_v$', loc="left")
+    axes[1,1].set_ylabel(r"$L_\infty$ error norm")
+    axes[1,1].set_title(r'$(\nabla \cdot \sigma)_v$')
     axes[1,1].set_xticks(ticks=[9e-3,2e-2,3e-2,4e-2,6e-2,7e-2,8e-2],minor=True)
     axes[1,1].set_xticklabels(labels=[None,None,None,None,None,None,None],minor=True)
     axes[1,1].set_xticks(ticks=[1e-2,5e-2],minor=False)
     axes[1,1].set_xticklabels(labels=[r'$10^{-2}$',r'$5\times10^{-2}$'],minor=False)
 
     plt.tight_layout(pad=0.5, w_pad=0.5, h_pad=0.5)
-    plt.savefig("stress_divergence_scaling_%s.png" %(testName),dpi=400)
+    plt.savefig("stress_divergence_scaling_per_random_%s.png" %(method),dpi=400)
+
+
 
 #-------------------------------------------------------------------------------
 
 if __name__ == "__main__":
 
-    parser = argparse.ArgumentParser(description='')
-
-    parser.add_argument('-t', dest='testName', help='')
-
-    args = parser.parse_args()
-
-    stress_divergence_scaling(args.testName)
+    stress_divergence_scaling_per_random()

--- a/testcases/square/operators_stress_divergence/create_ics.py
+++ b/testcases/square/operators_stress_divergence/create_ics.py
@@ -1,6 +1,7 @@
 from netCDF4 import Dataset
 import numpy as np
 from math import sin, cos, pi, radians
+import argparse
 
 #-------------------------------------------------------------
 
@@ -215,7 +216,7 @@ def create_ic(gridfile, icfile):
 
 #-------------------------------------------------------------
 
-def create_ics():
+def create_ics(testName):
 
     gridTypes = ["hex","quad"]
 
@@ -231,8 +232,8 @@ def create_ics():
     for gridType in gridTypes:
         for grid in grids[gridType]:
 
-            gridfile = "grid_%s_%s.nc" %(gridType,grid)
-            icfile = "ic_%s_%s.nc" %(gridType,grid)
+            gridfile = "grid_%s_%s_%s.nc" %(testName,gridType,grid)
+            icfile = "ic_%s_%s_%s.nc" %(testName,gridType,grid)
 
             create_ic(gridfile, icfile)
 
@@ -240,4 +241,10 @@ def create_ics():
 
 if __name__ == "__main__":
 
-    create_ics()
+    parser = argparse.ArgumentParser(description='')
+
+    parser.add_argument('-t', dest='testName', help='')
+
+    args = parser.parse_args()
+
+    create_ics(args.testName)

--- a/testcases/square/operators_stress_divergence/error_analysis_stress_divergence.py
+++ b/testcases/square/operators_stress_divergence/error_analysis_stress_divergence.py
@@ -1,9 +1,10 @@
 from netCDF4 import Dataset
 import numpy as np
+import argparse
 
 #-----------------------------------------------------------------------
 
-def error_analysis_stress_divergence():
+def error_analysis_stress_divergence(testName, ignoreWeak=False):
 
     # taylor series terms:
     # 0: f(x0,y0)
@@ -12,14 +13,20 @@ def error_analysis_stress_divergence():
     # 3: 1/2 d2f/dx2(x0,y0) \Delta x^2
     # 4: 1/2 d2f/dy2(x0,y0) \Delta y^2
     # 5: d2f/dxdy(x0,y0) \Delta x \Delta y
-    nTerms = 6
-    dxPow = [0,1,0,2,1,0]
-    dyPow = [0,0,1,0,1,2]
-    coeff = [1.0,1.0,1.0,0.5,1.0,0.5]
-    terms = ["f","df/dx","df/dy","d2f/dx2","d2f/dxdy","d2f/dy2"]
+    # 6: 1/6 d3f/dx3(x0,y0) \Delta x^3
+    # 7: 1/2 d3f/dx2dy(x0,y0) \Delta x^2 \Delta y
+    # 8: 1/2 d3f/dxdy2(x0,y0) \Delta x \Delta y^2
+    # 9: 1/6 d3f/dy3(x0,y0) \Delta y^3
+
+    nTerms = 10
+    dxPow = [0,1,0,2,1,0,3,2,1,0]
+    dyPow = [0,0,1,0,1,2,0,1,2,3]
+    coeff = [1.0,1.0,1.0,0.5,1.0,0.5,1.0/6.0,0.5,0.5,1.0/6.0]
+    terms = ["f","df/dx","df/dy","d2f/dx2","d2f/dxdy","d2f/dy2","d3f/dx3","d3f/dx2dy","d3f/dxdy2","d3f/dy3"]
 
 
-    fileout = open("error_report_stress_divergence.txt","w")
+    filenameOut = "error_report_stress_divergence_%s.txt" %(testName)
+    fileout = open(filenameOut,"w")
 
 
     gridTypes = ["hex","quad"]
@@ -32,7 +39,8 @@ def error_analysis_stress_divergence():
 
 
         # grid file
-        filegrid = Dataset("grid_%s_%s.nc" %(gridType,grids[gridType]),"r")
+        filenameGrid = "grid_%s_%s_%s.nc" %(testName,gridType,grids[gridType])
+        filegrid = Dataset(filenameGrid,"r")
 
         nVertices = len(filegrid.dimensions["nVertices"])
         vertexDegree = len(filegrid.dimensions["vertexDegree"])
@@ -87,20 +95,25 @@ def error_analysis_stress_divergence():
             fileout.write("   %s\n" %(basis))
 
             # variational
-            filein = Dataset("./output_%s_%s_%s/output.2000.nc" %(gridType,basis,grids[gridType]),"r")
+            filenameIn = "output_%s_%s_%s_%s/output.2000.nc" %(testName, gridType, basis, grids[gridType])
+            filein = Dataset(filenameIn,"r")
 
             basisIntegralsU = filein.variables["basisIntegralsU"][:]
             basisIntegralsV = filein.variables["basisIntegralsV"][:]
+            variationalDenominator = filein.variables["variationalDenominator"][:]
             cellVerticesAtVertex = filein.variables["cellVerticesAtVertex"][:]
             cellVerticesAtVertex[:] = cellVerticesAtVertex[:] - 1
 
             filein.close()
 
             # gradient taylor terms
-            dfdx = np.zeros(nTerms) # ideal: (0,1,0,0,0,0)
-            dfdy = np.zeros(nTerms) # ideal: (0,0,1,0,0,0)
+            dfdx = np.zeros(nTerms) # ideal: (0,1,0,0,0,0,0,0,0,0)
+            dfdy = np.zeros(nTerms) # ideal: (0,0,1,0,0,0,0,0,0,0)
 
             for iTerm in range(0,nTerms):
+
+                #sumBasisIntegralsU = 0.0
+                #sumBasisIntegralsV = 0.0
 
                 # loop over surrounding cells
                 for iSurroundingCell in range(0,vertexDegree):
@@ -121,8 +134,19 @@ def error_analysis_stress_divergence():
 
                         fTerm = coeff[iTerm] * pow(dx,dxPow[iTerm]) * pow(dy,dyPow[iTerm])
 
-                        dfdx[iTerm] -= (fTerm * basisIntegralsU[iCell,iVelocityVertex,iStressVertex]) / areaTriangle[iVertexTest]
-                        dfdy[iTerm] -= (fTerm * basisIntegralsV[iCell,iVelocityVertex,iStressVertex]) / areaTriangle[iVertexTest]
+                        dfdx[iTerm] -= (fTerm * basisIntegralsU[iCell,iVelocityVertex,iStressVertex]) / variationalDenominator[iVertexTest]
+                        dfdy[iTerm] -= (fTerm * basisIntegralsV[iCell,iVelocityVertex,iStressVertex]) / variationalDenominator[iVertexTest]
+
+                        #sumBasisIntegralsU += dx * basisIntegralsU[iCell,iVelocityVertex,iStressVertex]
+                        #sumBasisIntegralsV += dy * basisIntegralsV[iCell,iVelocityVertex,iStressVertex]
+
+                        #if (iTerm == 0):
+                        #    print("        sumBasisIntegralsU: ", iSurroundingCell, basisIntegralsU[iCell,iVelocityVertex,iStressVertex])
+                        #    print("        sumBasisIntegralsV: ", iSurroundingCell, basisIntegralsV[iCell,iVelocityVertex,iStressVertex])
+
+                #if (iTerm == 0):
+                #    print("      sumBasisIntegralsU: ", sumBasisIntegralsU, variationalDenominator[iVertexTest], areaTriangle[iVertexTest])
+                #    print("      sumBasisIntegralsV: ", sumBasisIntegralsV, variationalDenominator[iVertexTest], areaTriangle[iVertexTest])
 
             dfdxAvg = np.mean(dfdx,axis=0)
             dfdyAvg = np.mean(dfdy,axis=0)
@@ -135,54 +159,57 @@ def error_analysis_stress_divergence():
                 fileout.write("      %5i %-8s: % 20.15e % 20.15e\n" %(iTerm, terms[iTerm], dfdx[iTerm], dfdy[iTerm]))
 
         # weak
-        print("  Weak:")
-        fileout.write("  Weak:\n")
-        iVertexTest = 1123
+        if (not ignoreWeak):
 
-        # weak
-        filein = Dataset("./output_%s_weak_%s/output.2000.nc" %(gridType,grids[gridType]),"r")
+            print("  Weak:")
+            fileout.write("  Weak:\n")
+            iVertexTest = 1123
 
-        normalVectorTriangle = filein.variables["normalVectorTriangle"][:]
+            # weak
+            filenameIn = "output_%s_%s_weak_%s/output.2000.nc" %(testName, gridType, grid)
+            filein = Dataset(filenameIn,"r")
 
-        filein.close()
+            normalVectorTriangle = filein.variables["normalVectorTriangle"][:]
 
-
-        dfdx = np.zeros(nTerms) # ideal: (0,1,0,0,0,0)
-        dfdy = np.zeros(nTerms) # ideal: (0,0,1,0,0,0)
-
-        for iTerm in range(0,nTerms):
-
-            for iVertexDegree in range(0,vertexDegree):
-
-                # interpolated edge velocity
-                iEdge = edgesOnVertex[iVertexTest,iVertexDegree]
-
-                stressEdge = 0.0
-
-                for iCellOnEdge in range(0,2):
-
-                    iCell = cellsOnEdge[iEdge,iCellOnEdge]
-
-                    dx = xCell[iCell] - xVertex[iVertexTest]
-                    dy = yCell[iCell] - yVertex[iVertexTest]
-                    fTerm = coeff[iTerm] * pow(dx,dxPow[iTerm]) * pow(dy,dyPow[iTerm])
-
-                    stressEdge += fTerm
-
-                stressEdge *= 0.5
-
-                dfdx[iTerm] += (stressEdge * normalVectorTriangle[iVertexTest,iVertexDegree,0] * dcEdges[iEdge]) / areaTriangle[iVertexTest]
-                dfdy[iTerm] += (stressEdge * normalVectorTriangle[iVertexTest,iVertexDegree,1] * dcEdges[iEdge]) / areaTriangle[iVertexTest]
+            filein.close()
 
 
+            dfdx = np.zeros(nTerms) # ideal: (0,1,0,0,0,0)
+            dfdy = np.zeros(nTerms) # ideal: (0,0,1,0,0,0)
 
-        print("          # Term       df/dx                  df/dy")
-        print("          ---------------------------------------------------------")
-        fileout.write("          # Term       df/dx                  df/dy\n")
-        fileout.write("          ---------------------------------------------------------\n")
-        for iTerm in range(0,nTerms):
-            print("      %5i %-8s: % 20.15e % 20.15e" %(iTerm, terms[iTerm], dfdx[iTerm], dfdy[iTerm]))
-            fileout.write("      %5i %-8s: % 20.15e % 20.15e\n" %(iTerm, terms[iTerm], dfdx[iTerm], dfdy[iTerm]))
+            for iTerm in range(0,nTerms):
+
+                for iVertexDegree in range(0,vertexDegree):
+
+                    # interpolated edge velocity
+                    iEdge = edgesOnVertex[iVertexTest,iVertexDegree]
+
+                    stressEdge = 0.0
+
+                    for iCellOnEdge in range(0,2):
+
+                        iCell = cellsOnEdge[iEdge,iCellOnEdge]
+
+                        dx = xCell[iCell] - xVertex[iVertexTest]
+                        dy = yCell[iCell] - yVertex[iVertexTest]
+                        fTerm = coeff[iTerm] * pow(dx,dxPow[iTerm]) * pow(dy,dyPow[iTerm])
+
+                        stressEdge += fTerm
+
+                    stressEdge *= 0.5
+
+                    dfdx[iTerm] += (stressEdge * normalVectorTriangle[iVertexTest,iVertexDegree,0] * dcEdges[iEdge]) / areaTriangle[iVertexTest]
+                    dfdy[iTerm] += (stressEdge * normalVectorTriangle[iVertexTest,iVertexDegree,1] * dcEdges[iEdge]) / areaTriangle[iVertexTest]
+
+
+
+            print("          # Term       df/dx                  df/dy")
+            print("          ---------------------------------------------------------")
+            fileout.write("          # Term       df/dx                  df/dy\n")
+            fileout.write("          ---------------------------------------------------------\n")
+            for iTerm in range(0,nTerms):
+                print("      %5i %-8s: % 20.15e % 20.15e" %(iTerm, terms[iTerm], dfdx[iTerm], dfdy[iTerm]))
+                fileout.write("      %5i %-8s: % 20.15e % 20.15e\n" %(iTerm, terms[iTerm], dfdx[iTerm], dfdy[iTerm]))
 
 
     fileout.close()
@@ -191,4 +218,11 @@ def error_analysis_stress_divergence():
 
 if __name__ == "__main__":
 
-    error_analysis_stress_divergence()
+    parser = argparse.ArgumentParser(description='')
+
+    parser.add_argument('-t', dest='testName', help='')
+    parser.add_argument('-w', dest='ignoreWeak', action='store_true', help='')
+
+    args = parser.parse_args()
+
+    error_analysis_stress_divergence(args.testName, args.ignoreWeak)

--- a/testcases/square/operators_stress_divergence/namelist.seaice.stress_divergence
+++ b/testcases/square/operators_stress_divergence/namelist.seaice.stress_divergence
@@ -83,9 +83,9 @@
     config_constitutive_relation_type = 'none'
     config_stress_divergence_scheme = 'variational'
     config_variational_basis = 'wachspress'
-    config_variational_denominator_type = 'original'
+    config_variational_denominator_type = 'alternate'
     config_wachspress_integration_type = 'dunavant'
-    config_wachspress_integration_order = 8
+    config_wachspress_integration_order = 12
     config_average_variational_strain = false
     config_calc_velocity_masks = false
     config_use_air_stress = true

--- a/testcases/square/operators_stress_divergence/run_testcase.py
+++ b/testcases/square/operators_stress_divergence/run_testcase.py
@@ -1,15 +1,34 @@
+import argparse
 from create_grids import create_grids
 from create_ics import create_ics
 from run_model import run_model
 from stress_divergence_scaling import stress_divergence_scaling
 from error_analysis_stress_divergence import error_analysis_stress_divergence
 
-create_grids()
+#-------------------------------------------------------------------------------
 
-create_ics()
+def run_testcase(meshType, meshScale, ignoreWeak):
 
-run_model()
+    testName = create_grids(meshType, meshScale)
 
-stress_divergence_scaling()
+    create_ics(testName)
 
-error_analysis_stress_divergence()
+    run_model(testName, ignoreWeak)
+
+    stress_divergence_scaling(testName, ignoreWeak)
+
+    error_analysis_stress_divergence(testName, ignoreWeak)
+
+#-------------------------------------------------------------------------------
+
+if __name__ == "__main__" :
+
+    parser = argparse.ArgumentParser(description='')
+
+    parser.add_argument('-t', dest='meshType', default="regular", choices=['regular','random','scale_x','scale_y'], help='')
+    parser.add_argument('-s', dest='meshScale', type=float, help='')
+    parser.add_argument('-w', dest='ignoreWeak', action='store_true', help='')
+
+    args = parser.parse_args()
+
+    run_testcase(args.meshType, args.meshScale, args.ignoreWeak)

--- a/testcases/square/operators_stress_divergence/streams.seaice.stress_divergence
+++ b/testcases/square/operators_stress_divergence/streams.seaice.stress_divergence
@@ -70,6 +70,7 @@
 	<var name="basisGradientU"/>
 	<var name="basisGradientV"/>
 	<var name="normalVectorTriangle"/>
+        <var name="variationalDenominator"/>
 </stream>
 
 <immutable_stream name="LYqSixHourlyForcing"

--- a/testcases/square/operators_stress_divergence/stress_divergence_scaling_per_random.py
+++ b/testcases/square/operators_stress_divergence/stress_divergence_scaling_per_random.py
@@ -1,0 +1,136 @@
+from stress_divergence_scaling import get_use_vertex, get_norm_integral_triangle, get_norm, get_resolution, scaling_lines
+import matplotlib.pyplot as plt
+
+#-------------------------------------------------------------------------------
+
+def stress_divergence_scaling_per_random():
+
+    gridType = "hex"
+    operatorMethod = "pwl"
+
+
+    grids = ["0082x0094",
+             "0164x0188",
+             "0328x0376",
+             "0656x0752"]
+
+    meshScales = [0.0,0.01,0.02,0.05,0.1]
+
+
+    # scaling lines
+    xMin = 2e-3
+    xMax = 3.5e-3
+    yMin = {"L2":1.5e-3,
+            "Linf":5e-1}
+
+    # plot
+    cm = 1/2.54  # centimeters in inches
+    plt.rc('font', family='Times New Roman', size=8)
+    plt.rc('mathtext',fontset="stix")
+    SMALL_SIZE = 8
+    MEDIUM_SIZE = 8
+    BIGGER_SIZE = 8
+    plt.rc('font', size=SMALL_SIZE)          # controls default text sizes
+    plt.rc('axes', titlesize=SMALL_SIZE)     # fontsize of the axes title
+    plt.rc('axes', labelsize=MEDIUM_SIZE)    # fontsize of the x and y labels
+    plt.rc('xtick', labelsize=SMALL_SIZE)    # fontsize of the tick labels
+    plt.rc('ytick', labelsize=SMALL_SIZE)    # fontsize of the tick labels
+    plt.rc('legend', fontsize=SMALL_SIZE)    # legend fontsize
+    plt.rc('figure', titlesize=BIGGER_SIZE)  # fontsize of the figure title
+
+
+    fig, axes = plt.subplots(2, 2, figsize=(15*cm,15*cm))
+
+    scaling_lines(axes[0,0], xMin, xMax, yMin["L2"])
+    scaling_lines(axes[0,1], xMin, xMax, yMin["L2"])
+    scaling_lines(axes[1,0], xMin, xMax, yMin["Linf"])
+    scaling_lines(axes[1,1], xMin, xMax, yMin["Linf"])
+
+    for meshScale in meshScales:
+
+        print("Mesh scale: ", meshScale)
+
+        testName = "random_%f" %(meshScale)
+
+        x = []
+        y_L2U = []
+        y_L2V = []
+        y_LinfU = []
+        y_LinfV = []
+
+        for grid in grids:
+
+            print("  Grid: ", grid)
+
+            filenameIC = "ic_%s_%s_%s.nc" %(testName, gridType, grid)
+            filename = "output_%s_%s_%s_%s/output.2000.nc" %(testName, gridType, operatorMethod, grid)
+            print("    ", filename, filenameIC)
+
+            useVertex = get_use_vertex(filename)
+
+            if (gridType == "hex"):
+                #L2_normU, L2_normV, Linf_normU, Linf_normV = get_norm_integral_triangle(filenameIC, filename, useVertex)
+                L2_normU, L2_normV, Linf_normU, Linf_normV = get_norm(filenameIC, filename, useVertex)
+            elif (gridType == "quad"):
+                #L2_normU, L2_normV, Linf_normU, Linf_normV = get_norm_integral_square(filenameIC, filename, useVertex)
+                L2_normU, L2_normV, Linf_normU, Linf_normV = get_norm(filenameIC, filename, useVertex)
+
+            x.append(get_resolution(filename, useVertex))
+            y_L2U.append(L2_normU)
+            y_L2V.append(L2_normV)
+            y_LinfU.append(Linf_normU)
+            y_LinfV.append(Linf_normV)
+
+        axes[0,0].loglog(x, y_L2U, markersize=5.0, label="%f" %(meshScale))
+        axes[0,1].loglog(x, y_L2V, markersize=5.0, label="%f" %(meshScale))
+        axes[1,0].loglog(x, y_LinfU, markersize=5.0, label="%f" %(meshScale))
+        axes[1,1].loglog(x, y_LinfV, markersize=5.0, label="%f" %(meshScale))
+
+    axes[0,0].legend(frameon=False, loc=2, fontsize=8, handlelength=2)
+    axes[0,0].set_xlabel(None)
+    axes[0,0].set_ylabel(r"$L_2$ error norm")
+    axes[0,0].set_title(r"(a) $(\nabla \cdot \sigma)_u$",loc="left")
+    axes[0,0].set_xticks(ticks=[3e-3,4e-3,5e-3,6e-3,7e-3,8e-3,9e-3],minor=True)
+    axes[0,0].set_xticklabels(labels=[None,None,None,None,None,None,None],minor=True)
+    axes[0,0].set_xticks(ticks=[2e-3,1e-2],minor=False)
+    axes[0,0].set_xticklabels(labels=[r'$2\times 10^{-3}$',r'$10^{-2}$'],minor=False)
+
+    axes[0,1].legend(frameon=False, loc=2, fontsize=8, handlelength=2)
+    axes[0,1].set_xlabel(None)
+    axes[0,1].set_ylabel(None)
+    axes[0,1].set_title(r"(b) $(\nabla \cdot \sigma)_v$",loc="left")
+    axes[0,1].set_xticks(ticks=[3e-3,4e-3,5e-3,6e-3,7e-3,8e-3,9e-3],minor=True)
+    axes[0,1].set_xticklabels(labels=[None,None,None,None,None,None,None],minor=True)
+    axes[0,1].set_xticks(ticks=[2e-3,1e-2],minor=False)
+    axes[0,1].set_xticklabels(labels=[r'$2\times 10^{-3}$',r'$10^{-2}$'],minor=False)
+
+    axes[1,0].legend(frameon=False, loc=2, fontsize=8, handlelength=2)
+    axes[1,0].set_xlabel("Grid resolution")
+    axes[1,0].set_ylabel(r"$L_\infty$ error norm")
+    axes[1,0].set_title(r"(c) $(\nabla \cdot \sigma)_u$",loc="left")
+    axes[1,0].set_xticks(ticks=[3e-3,4e-3,5e-3,6e-3,7e-3,8e-3,9e-3],minor=True)
+    axes[1,0].set_xticklabels(labels=[None,None,None,None,None,None,None],minor=True)
+    axes[1,0].set_xticks(ticks=[2e-3,1e-2],minor=False)
+    axes[1,0].set_xticklabels(labels=[r'$2\times 10^{-3}$',r'$10^{-2}$'],minor=False)
+
+    axes[1,1].legend(frameon=False, loc=2, fontsize=8, handlelength=2)
+    axes[1,1].set_xlabel("Grid resolution")
+    axes[1,1].set_ylabel(None)
+    axes[1,1].set_title(r"(d) $(\nabla \cdot \sigma)_v$",loc="left")
+    axes[1,1].set_xticks(ticks=[3e-3,4e-3,5e-3,6e-3,7e-3,8e-3,9e-3],minor=True)
+    axes[1,1].set_xticklabels(labels=[None,None,None,None,None,None,None],minor=True)
+    axes[1,1].set_xticks(ticks=[2e-3,1e-2],minor=False)
+    axes[1,1].set_xticklabels(labels=[r'$2\times 10^{-3}$',r'$10^{-2}$'],minor=False)
+
+
+    plt.tight_layout(pad=0.2, w_pad=0.6, h_pad=0.2)
+    filenameOut = "stress_divergence_scaling_per_random.png"
+    plt.savefig(filenameOut,dpi=300)
+    filenameOut = "stress_divergence_scaling_per_random.eps"
+    plt.savefig(filenameOut)
+
+#-------------------------------------------------------------------------------
+
+if __name__ == "__main__":
+
+    stress_divergence_scaling_per_random()


### PR DESCRIPTION
Planar and spherical meshes for stress divergence test cases can have a varying amount of randomness added to vertex and cell positions (edge points are calculted from the mesh converter)